### PR TITLE
fix s3.put_bucket_acl with s3.put_bucket_ownership_controls

### DIFF
--- a/lib/s3_secure/access_logs/enable.rb
+++ b/lib/s3_secure/access_logs/enable.rb
@@ -13,6 +13,17 @@ module S3Secure::AccessLogs
         return
       end
 
+      # require to add in order to use put_bucket_acl since this change
+      # https://aws.amazon.com/blogs/aws/amazon-s3-block-public-access-another-layer-of-protection-for-your-accounts-and-buckets/
+      s3.put_bucket_ownership_controls(
+        bucket: @bucket,
+        ownership_controls: { # required
+          rules: [ # required
+            {object_ownership: "ObjectWriter"}, # required, accepts BucketOwnerPreferred, ObjectWriter, BucketOwnerEnforced
+          ],
+        },
+      )
+
       s3.put_bucket_acl(
         bucket: @bucket,
         access_control_policy: @show.access_control_policy_with_log_delivery_permissions,


### PR DESCRIPTION
## Summary

AWS changed the default behavior of s3 buckets to block public access. This broke the `s3.put_bucket_acl call`. The fix is to use `put_bucket_ownership_controls` to add back the ability to add ACL first.

This fixes that bug introduced by the AWS bucket default policy change.

Related

* https://community.boltops.com/t/new-s3-backend-fails-due-to-acl-rule/1070
* https://aws.amazon.com/blogs/aws/amazon-s3-block-public-access-another-layer-of-protection-for-your-accounts-and-buckets/
* https://github.com/boltops-tools/jets/pull/639
